### PR TITLE
fixed a bug when computing a jump forward connection value.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.11"
+pretty_env_logger = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,6 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.11"
+
+[dev-dependencies]
 pretty_env_logger = "0.4.0"


### PR DESCRIPTION
Before it would include the neuron weight and also the weight of jump forward which leads to wrong results. See the test "test_genome_is_correct" which is a genome from the phd paper on EANT and has weights other than one. In the original Test "test_network_eval" this bug was not noticed as all the weight are 1.0 meaning the neuron connection weight had no influence on the jump forward connection.
I used Figure 5.3 in the paper (link in network::tests) to compute the network output manually and checked it twice for correctness. The important line from the paper is on page 101: " Finally, push the result of computation with the weight associated with forward jumper node onto the stack", which was not the case in original implementation ( as it also multiplied by regular neuron connection weight) The original test still works fine.  Sorry for all the unnecessary line changes, my IDE (CLion) does this automatically.